### PR TITLE
Allow Laravel 13 (`^13.0`)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,9 @@
     ],
     "require": {
         "php": ">=7.0.0",
-        "illuminate/database": "^5.0|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
-        "illuminate/support": "^5.0|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
-        "illuminate/validation": "^5.0|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0"
+        "illuminate/database": "^5.0|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
+        "illuminate/support": "^5.0|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
+        "illuminate/validation": "^5.0|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0|^13.0"
     },
     "require-dev": {
         "roave/security-advisories": "dev-latest",


### PR DESCRIPTION
## What

Add `^13.0` to `illuminate/database`, `illuminate/support`, `illuminate/validation` constraints in `composer.json`.

## Why

Used (transitively via `padosoftcms/padosoftcms-admin`) by [gescat-laravel](https://github.com/padosoft/gescat-laravel) on branch `shift-174733` (upgrade Laravel 12 → 13).

## Compatibility

Additive only — no breaking changes. The `|^13.0` is appended after the existing range.

## Patch

See [5da9835](https://github.com/luca9692/laravel-validable/commit/5da983524e2af15b68d624645fc168317cdf3e75) — 3 lines changed.